### PR TITLE
Add sizing to `iron-image`

### DIFF
--- a/kwc-challenge-set.html
+++ b/kwc-challenge-set.html
@@ -151,7 +151,7 @@ To display a set of challenges for the user to complete.
                 <div class="circle-content">
                     <div id="canvas"></div>
                     <div id="progress"></div>
-                    <iron-image src="[[_computeCompleteImage(_completed)]]"></iron-image>
+                    <iron-image src="[[_computeCompleteImage(_completed)]]" sizing="contain"></iron-image>
                 </div>
             </div>
 


### PR DESCRIPTION
Add `sizing="contain"` to `iron-image` so hexagon shaped badges won't bleed out and overflow the image container.