### PR TITLE
Set default value for `showMedals` to true

### DIFF
--- a/kwc-challenge-set.html
+++ b/kwc-challenge-set.html
@@ -363,7 +363,7 @@ To display a set of challenges for the user to complete.
                  */
                 showMedals: {
                     type: Boolean,
-                    value: false
+                    value: true
                 }
             },
             observers:  [


### PR DESCRIPTION
So it's not a breaking change: If it is not passed through, it works as previously