### PR TITLE
Remove opacity of disabled sets

### DIFF
--- a/kwc-challenge-set.html
+++ b/kwc-challenge-set.html
@@ -33,7 +33,6 @@ To display a set of challenges for the user to complete.
             }
             #container[disabled] {
                 filter: grayscale(100%);
-                opacity: 0.5;
             }
             #container[disabled] .stepCircle.unlocked {
                 cursor: initial;


### PR DESCRIPTION
Remove opacity on disabled challenge sets to improve display on low contrast screens (Computer Kits, for example)

https://trello.com/c/CVSDxqEf