### PR TITLE
Add xlink namespace for SVG <image> elements

### DIFF
--- a/kwc-challenge-set.html
+++ b/kwc-challenge-set.html
@@ -297,439 +297,457 @@ To display a set of challenges for the user to complete.
         </div>
     </template>
     <script>
-        Polymer({
-            is: 'kwc-challenge-set',
-            properties: {
-                /*
-                 * The data for the challenge set to build a progress bar for.
-                 * @type {Object}
-                 */
-                challengeSet: {
-                    type: Object,
-                    value: () => {
-                        return {};
+        (function () {
+            /** Namspace definitions for SVG elements */
+            const XMLNS = 'http://www.w3.org/2000/svg';
+            const XLINK = 'http://www.w3.org/1999/xlink';
+
+            Polymer({
+                is: 'kwc-challenge-set',
+                properties: {
+                    /*
+                     * The data for the challenge set to build a progress bar
+                     * for.
+                     * @type {Object}
+                     */
+                    challengeSet: {
+                        type: Object,
+                        value: () => {
+                            return {};
+                        }
+                    },
+                    /*
+                     * A number representing the number of challenges in this
+                     * set that are completed.
+                     * @type {Number}
+                     */
+                    progress: {
+                        type: Number,
+                        value: 0
+                    },
+                    _nextChallenge: {
+                        type: Object,
+                        value: () => {
+                            return {};
+                        }
+                    },
+                    _numNodes: {
+                        type: Number,
+                        computed: '_computeNumNodes(challengeSet)'
+                    },
+                    /*
+                     * The radius of each challenge progress circle in the
+                     * progress bar.
+                     */
+                    radius: {
+                        type: Number,
+                        value: 125
+                    },
+                    /*
+                     * The url of the current user's avatar. If none given a
+                     * default icon is used.
+                     */
+                    avatarUrl: {
+                        type: String,
+                        value: null
+                    },
+                    _avatarUrl: {
+                        type: String,
+                        computed: '_computeIconUrl("avatar", avatarUrl)'
+                    },
+                    /*
+                     * A url to use for completed challenges in the progess bar
+                     */
+                    completeIconUrl: {
+                        type: String,
+                        value: null
+                    },
+                    _completeIconUrl: {
+                        type: String,
+                        computed: '_computeIconUrl("complete", completeIconUrl)'
+                    },
+                    /*
+                     * A url for an icon to use for the current challenge in
+                     * the progress bar.
+                     */
+                    currentIconUrl: {
+                        type: String,
+                        value: null
+                    },
+                    _currentIconUrl: {
+                        type: String,
+                        computed: '_computeIconUrl("current", currentIconUrl)'
+                    },
+                    /*
+                     * A url for an icon to used for locked challenges on the
+                     * progress bar.
+                     */
+                    lockedIconUrl: {
+                        type: String,
+                        value: null
+                    },
+                    _lockedIconUrl: {
+                        type: String,
+                        computed: '_computeIconUrl("locked", lockedIconUrl)'
+                    },
+                    _completed: {
+                        type: Boolean,
+                        computed: '_computeComplete(progress, challengeSet.challenges.length)'
+                    },
+                    /**
+                     * Flags if this challenge set is disabled
+                     * @type {Boolean}
+                     */
+                    disabled: {
+                        type: Boolean,
+                        value: false
+                    },
+                    /**
+                     * Media query-matched property to determine layout
+                     * @type {Boolean}
+                     */
+                    horizontal: {
+                        type: Boolean,
+                        reflectToAttribute: true
+                    },
+                    /**
+                     * Media query-matched property to determine layout
+                     * @type {Boolean}
+                     */
+                    vertical: {
+                        type: Boolean,
+                        reflectToAttribute: true
+                    },
+                    /**
+                     * Flags if, after completing a challenge set, the user
+                     * should see the medal (badges) unlocked in the challenge
+                     * set circle.
+                     * @type {Boolean}
+                     */
+                    showMedals: {
+                        type: Boolean,
+                        value: true
+                    },
+                    buttonLabel: {
+                        type: String,
+                        computed: '_computeButtonLabel(_completed, progress)'
+                    },
+                    buttonLabel: {
+                        type: String,
+                        computed: '_computeButtonLabel(_completed, progress)'
+                    },
+                    /**
+                     * Flags if challenge-friend button is hidden
+                     * @type {Boolean}
+                     */
+                    hideChallengeFriend: {
+                        type: Boolean,
+                        value: false
                     }
                 },
-                /*
-                 * A number representing the number of challenges in this set that are completed.
-                 * @type {Number}
-                 */
-                progress: {
-                    type: Number,
-                    value: 0
+                observers:  [
+                    '_onProgressChanged(progress, radius, _currentIconUrl, _lockedIconUrl, _completeIconUrl, challengeSet.*)'
+                ],
+                attached () {
+                    this._drawChallengeProgress();
                 },
-                _nextChallenge: {
-                    type: Object,
-                    value: () => {
-                        return {};
+                _hasData (challengeSet) {
+                    return challengeSet && challengeSet.challenges && challengeSet.challenges.length;
+                },
+                _computeIconUrl (name, propUrl) {
+                    if (propUrl){
+                        return propUrl
                     }
-                },
-                _numNodes: {
-                    type: Number,
-                    computed: '_computeNumNodes(challengeSet)'
-                },
-                /*
-                 * The radius of each challenge progress circle in the progress bar.
-                 */
-                radius: {
-                    type: Number,
-                    value: 125
-                },
-                /*
-                 * The url of the current user's avatar. If none given a default icon is used.
-                 */
-                avatarUrl: {
-                    type: String,
-                    value: null
-                },
-                _avatarUrl: {
-                    type: String,
-                    computed: '_computeIconUrl("avatar", avatarUrl)'
-                },
-                /*
-                 * A url to use for completed challenges in the progess bar
-                 */
-                completeIconUrl: {
-                    type: String,
-                    value: null
-                },
-                _completeIconUrl: {
-                    type: String,
-                    computed: '_computeIconUrl("complete", completeIconUrl)'
-                },
-                /*
-                 * A url for an icon to use for the current challenge in the progress bar.
-                 */
-                currentIconUrl: {
-                    type: String,
-                    value: null
-                },
-                _currentIconUrl: {
-                    type: String,
-                    computed: '_computeIconUrl("current", currentIconUrl)'
-                },
-                /*
-                 * A url for an icon to used for locked challenges on the progress bar.
-                 */
-                lockedIconUrl: {
-                    type: String,
-                    value: null
-                },
-                _lockedIconUrl: {
-                    type: String,
-                    computed: '_computeIconUrl("locked", lockedIconUrl)'
-                },
-                _completed: {
-                    type: Boolean,
-                    computed: '_computeComplete(progress, challengeSet.challenges.length)'
+                    return KwcChallengeSet.assets[name];
                 },
                 /**
-                 * Flags if this challenge set is disabled
-                 * @type {Boolean}
+                 * Gets the encoded svg as a string ready to be placed on a
+                 * `src` attribute. Assets stored on
+                 * `scripts/getMedalButton.htm` as a dictionary.
+                 * @param {String} name Key on the asset dictionary.
+                 * @return {String}
                  */
-                disabled: {
-                    type: Boolean,
-                    value: false
+                _computeGetMedalButtonUrl (name) {
+                    return KwcGetMedal.assets[name];
                 },
-                /**
-                 * Media query-matched property to determine layout
-                 * @type {Boolean}
-                 */
-                horizontal: {
-                    type: Boolean,
-                    reflectToAttribute: true
+                _computeButtonText (completed) {
+                    return completed ? 'redo' : 'continue';
                 },
-                /**
-                 * Media query-matched property to determine layout
-                 * @type {Boolean}
-                 */
-                vertical: {
-                    type: Boolean,
-                    reflectToAttribute: true
+                _computeComplete (progress, total) {
+                    return progress >= total;
                 },
-                /**
-                 * Flags if, after completing a challenge set, the user
-                 * should see the medal (badges) unlocked in the challenge
-                 * set circle.
-                 * @type {Boolean}
-                 */
-                showMedals: {
-                    type: Boolean,
-                    value: true
-                },
-                buttonLabel: {
-                    type: String,
-                    computed: '_computeButtonLabel(_completed, progress)'
-                },
-                buttonLabel: {
-                    type: String,
-                    computed: '_computeButtonLabel(_completed, progress)'
-                },
-                /**
-                 * Flags if challenge-friend button is hidden
-                 * @type {Boolean}
-                 */
-                hideChallengeFriend: {
-                    type: Boolean,
-                    value: false
-                }
-            },
-            observers:  [
-                '_onProgressChanged(progress, radius, _currentIconUrl, _lockedIconUrl, _completeIconUrl, challengeSet.*)'
-            ],
-            attached () {
-                this._drawChallengeProgress();
-            },
-            _hasData (challengeSet) {
-                return challengeSet && challengeSet.challenges && challengeSet.challenges.length;
-            },
-            _computeIconUrl (name, propUrl) {
-                if (propUrl){
-                    return propUrl
-                }
-                return KwcChallengeSet.assets[name];
-            },
-            /**
-             * Gets the encoded svg as a string ready to be placed on a `src`
-             * attribute. Assets stored on `scripts/getMedalButton.htm` as a
-             * dictionary.
-             * @param {String} name Key on the asset dictionary.
-             * @return {String}
-             */
-            _computeGetMedalButtonUrl (name) {
-                return KwcGetMedal.assets[name];
-            },
-            _computeButtonText (completed) {
-                return completed ? 'redo' : 'continue';
-            },
-            _computeComplete (progress, total) {
-                return progress >= total;
-            },
-            _computeProgressText (progress, completed) {
-                if (!this.challengeSet || !this.challengeSet.challenges) {
-                    return '0 / 0';
-                }
-                if (!completed) {
-                    return `${progress || 0} / ${this.challengeSet.challenges.length}`;
-                } else {
-                    return 'complete';
-                }
-            },
-            _computeNumNodes (challengeSet) {
-                if (!challengeSet || !challengeSet.challenges) {
-                    return 0;
-                }
-                return challengeSet.challenges.length;
-            },
-            _computeCompleteClass (completed) {
-                return completed ? 'control-complete' : 'control-subtitle';
-            },
-
-            _computeCompleteImage (completed, showMedals) {
-                if (completed && showMedals) {
-                    return this.challengeSet['medal-enabled'];
-                } else {
-                    return this.challengeSet['medal-disabled'];
-                }
-            },
-            /**
-             * Calculates if user has completed the challenge set but it's not
-             * allowed to see the badge and clicks it.
-             * @param {Boolean} completed Flags if the challenge set is complete
-             * @param {Boolean} showMedals Flags if user is allowed to see the
-             *     medal once the challenge set is complete
-             * @return {Boolean}
-             */
-            _isUpForClaim (completed, showMedals) {
-                return completed && !showMedals;
-            },
-            /**
-             * Fired when a medal that is up to be claimed is clicked.
-             *
-             * @event disabled-medal-clicked
-             * @param {Object} challengeSet Challenge set for the clicked medal.
-             */
-            /**
-             * Handles tap/click event on "claim medal" button.
-             * If user has completed the challenge set but it's not allowed
-             * to see the badge and clicks it, fire event to  so the parent can
-             * hint on how to enable the medal (badge).
-             */
-            _claimMedalClicked () {
-                this.dispatchEvent(
-                    new CustomEvent(
-                        'disabled-medal-clicked',
-                        { detail: this.challengeSet }
-                    )
-                );
-            },
-            _createNodes (_numNodes, _radius) {
-                let nodes = [],
-                    width = (_radius * 2) + 50,
-                    height = (_radius * 2) + 50,
-                    angle,
-                    x,
-                    y,
-                    i;
-
-                for (i = 0; i < _numNodes; i++) {
-                    angle = ((i / (_numNodes / 2)) * Math.PI) - (90 * (Math.PI / 180)) + (2 * (Math.PI / _numNodes));
-                    x = (_radius * Math.cos(angle)) + (width / 2);
-                    y = (_radius * Math.sin(angle)) + (width / 2);
-                    nodes.push({'id': i, 'x': x, 'y': y});
-                }
-                return nodes;
-            },
-            _createChallengeSvg (_radius, callback) {
-                let svgContainer = this.$.progress,
-                    xmlns = 'http://www.w3.org/2000/svg',
-                    svg = document.createElementNS(xmlns, 'svg');
-                if (!svgContainer){ return; }
-                svgContainer.innerHTML = '';
-                svg.setAttribute('viewBox', `0 0 ${(_radius * 2) + 50} ${(_radius * 2) + 50}`);
-                svg.setAttribute('id', 'progressContainer');
-                Polymer.dom(svgContainer).appendChild(svg);
-                callback(svg);
-            },
-            _drawStepCircles (svg, nodes, elementRadius) {
-                let xmlns = 'http://www.w3.org/2000/svg',
-                    element = svg;
-                if (!this.progress) {
-                    this.progress = 0;
-                }
-                for (let i = 0; i < nodes.length; i++) {
-                    let stepCircle = document.createElementNS(xmlns, 'image');
-                    stepCircle.setAttribute('index', i);
-                    stepCircle.setAttribute('class', 'stepCircle');
-                    stepCircle.setAttributeNS(null, 'height', '50');
-                    stepCircle.setAttributeNS(null, 'width', '50');
-                    stepCircle.setAttribute('x', (nodes[i].x - 25));
-                    stepCircle.setAttribute('y', (nodes[i].y - 25));
-                    stepCircle.onclick = this._onChallengeClick.bind(this);
-                    if (i < this.progress) {
-                        stepCircle.setAttribute('class', 'stepCircle unlocked');
-                        stepCircle.setAttributeNS(null, 'href', this._completeIconUrl);
-                        Polymer.dom(element).appendChild(stepCircle);
-                    } else if (i === this.progress) {
-                        stepCircle.setAttributeNS(null, 'href', this._currentIconUrl);
-                        stepCircle.setAttribute('class', 'stepCircle unlocked');
-                        let avatar = document.createElementNS(xmlns, 'image');
-                        avatar.setAttribute('class', 'stepCircle unlocked');
-                        avatar.setAttributeNS(null, 'height', '25');
-                        avatar.setAttributeNS(null, 'width', '25');
-                        avatar.setAttributeNS(null, 'href', this._avatarUrl);
-                        avatar.setAttribute('cursor', 'pointer');
-                        avatar.setAttribute('x', (nodes[i].x - 12));
-                        avatar.setAttribute('y', (nodes[i].y - 12));
-                        avatar.setAttribute('index', i);
-                        avatar.onclick = this._onChallengeClick.bind(this);
-                        Polymer.dom(element).appendChild(stepCircle);
-                        Polymer.dom(element).appendChild(avatar);
+                _computeProgressText (progress, completed) {
+                    if (!this.challengeSet || !this.challengeSet.challenges) {
+                        return '0 / 0';
+                    }
+                    if (!completed) {
+                        return `${progress || 0} / ${this.challengeSet.challenges.length}`;
                     } else {
-                        stepCircle.setAttributeNS(null, 'href', this._lockedIconUrl);
-                        Polymer.dom(element).appendChild(stepCircle);
+                        return 'complete';
                     }
-                }
-            },
-            _describeArc (x, y, radius, startAngle, endAngle) {
-                endAngle = endAngle || 360;
-                let start = this._polarToCartesian(x, y, radius, endAngle),
-                    end = this._polarToCartesian(x, y, radius, startAngle),
-                    largeArcFlag = endAngle - startAngle <= 180 ? '0' : '1',
-                    d = [
-                        'M', start.x, start.y,
-                        'A', radius, radius, 0, largeArcFlag, 0, end.x, end.y
-                    ].join(' ');
-                return d;
-            },
-            _polarToCartesian (centerX, centerY, radius, angleInDegrees) {
-                let angleInRadians = (angleInDegrees - 90) * Math.PI / 180.0;
-                return {
-                        x: centerX + (radius * Math.cos(angleInRadians)),
-                        y: centerY + (radius * Math.sin(angleInRadians))
-                    };
-            },
-            _drawChallengeProgress () {
-                let nodes = this._createNodes(this._numNodes, this.radius),
-                    xmlns = 'http://www.w3.org/2000/svg';
-                if (!nodes.length){ return; }
-                this._createChallengeSvg(this.radius,  svg => {
-                    let polyline = document.createElementNS(xmlns, 'polyline');
-                    polyline.style.strokeDasharray = 4.5;
+                },
+                _computeNumNodes (challengeSet) {
+                    if (!challengeSet || !challengeSet.challenges) {
+                        return 0;
+                    }
+                    return challengeSet.challenges.length;
+                },
+                _computeCompleteClass (completed) {
+                    return completed ? 'control-complete' : 'control-subtitle';
+                },
 
-                    polyline.setAttribute('points',
-                        nodes[this._numNodes - 1].x + ',' + nodes[this._numNodes - 1].y +
-                        ' ' + nodes[this._numNodes - 1].x + ',' +
-                        (nodes[this._numNodes - 1].y + this.radius / 2) + ' '
+                _computeCompleteImage (completed, showMedals) {
+                    if (completed && showMedals) {
+                        return this.challengeSet['medal-enabled'];
+                    } else {
+                        return this.challengeSet['medal-disabled'];
+                    }
+                },
+                /**
+                 * Calculates if user has completed the challenge set but it's
+                 * not allowed to see the badge and clicks it.
+                 * @param {Boolean} completed Flags if the challenge set is
+                 * complete
+                 * @param {Boolean} showMedals Flags if user is allowed to see
+                 * the medal once the challenge set is complete
+                 * @return {Boolean}
+                 */
+                _isUpForClaim (completed, showMedals) {
+                    return completed && !showMedals;
+                },
+                /**
+                 * Fired when a medal that is up to be claimed is clicked.
+                 * @event disabled-medal-clicked
+                 * @param {Object} challengeSet Challenge set for the clicked
+                 * medal.
+                 */
+                /**
+                 * Handles tap/click event on "claim medal" button.
+                 * If user has completed the challenge set but it's not allowed
+                 * to see the badge and clicks it, fire event to  so the parent
+                 * can hint on how to enable the medal (badge).
+                 */
+                _claimMedalClicked () {
+                    this.dispatchEvent(
+                        new CustomEvent(
+                            'disabled-medal-clicked',
+                            { detail: this.challengeSet }
+                        )
                     );
-                    polyline.setAttribute('stroke', '#e0e1e3');
-                    polyline.setAttribute('stroke-width', 7);
-                    if (this._completed) {
-                        polyline.setAttribute('stroke', '#ffb300');
-                        polyline.style.strokeDasharray = 'none';
-                    }
-                    element = svg;
-                    Polymer.dom(element).appendChild(polyline);
-                    let arc = document.createElementNS(xmlns, 'path');
-                    arc.setAttribute('d', this._describeArc(
-                        this.radius + 25,
-                        this.radius + 25,
-                        this.radius,
-                        360 / this._numNodes,
-                        360));
-                    arc.setAttribute('stroke', '#e0e1e3');
-                    arc.setAttribute('stroke-width', 7);
-                    arc.style.strokeDasharray = 4.5;
-                    arc.setAttribute('fill', 'none');
-                    if (this._completed) {
-                        arc.setAttribute('stroke', '#ffb300');
-                        arc.style.strokeDasharray = 'none';
-                    }
-                    Polymer.dom(element).appendChild(arc);
+                },
+                _createNodes (_numNodes, _radius) {
+                    let nodes = [],
+                        width = (_radius * 2) + 50,
+                        height = (_radius * 2) + 50,
+                        angle,
+                        x,
+                        y,
+                        i;
 
-                    let progressArc = document.createElementNS(xmlns, 'path');
-                    progressArc.setAttribute('d', this._describeArc(
-                        this.radius + 25,
-                        this.radius + 25,
-                        this.radius,
-                        360 / this._numNodes,
-                        (360 / this._numNodes) * (this.progress + 1)));
-                    progressArc.setAttribute('stroke', '#ffb300');
-                    progressArc.setAttribute('stroke-width', 7);
-                    progressArc.setAttribute('fill', 'none');
-                    Polymer.dom(element).appendChild(progressArc);
+                    for (i = 0; i < _numNodes; i++) {
+                        angle = ((i / (_numNodes / 2)) * Math.PI) - (90 * (Math.PI / 180)) + (2 * (Math.PI / _numNodes));
+                        x = (_radius * Math.cos(angle)) + (width / 2);
+                        y = (_radius * Math.sin(angle)) + (width / 2);
+                        nodes.push({'id': i, 'x': x, 'y': y});
+                    }
+                    return nodes;
+                },
+                _createChallengeSvg (_radius, callback) {
+                    let svgContainer = this.$.progress,
+                        svg = document.createElementNS(XMLNS, 'svg');
+                    if (!svgContainer){ return; }
+                    svgContainer.innerHTML = '';
+                    svg.setAttribute('viewBox', `0 0 ${(_radius * 2) + 50} ${(_radius * 2) + 50}`);
+                    svg.setAttribute('id', 'progressContainer');
+                    Polymer.dom(svgContainer).appendChild(svg);
+                    callback(svg);
+                },
+                _drawStepCircles (svg, nodes, elementRadius) {
+                    let element = svg;
+                    if (!this.progress) {
+                        this.progress = 0;
+                    }
+                    for (let i = 0; i < nodes.length; i++) {
+                        let stepCircle = document.createElementNS(XMLNS, 'image');
+                        stepCircle.setAttribute('index', i);
+                        stepCircle.setAttribute('class', 'stepCircle');
+                        stepCircle.setAttributeNS(null, 'height', '50');
+                        stepCircle.setAttributeNS(null, 'width', '50');
+                        stepCircle.setAttribute('x', (nodes[i].x - 25));
+                        stepCircle.setAttribute('y', (nodes[i].y - 25));
+                        stepCircle.onclick = this._onChallengeClick.bind(this);
+                        if (i < this.progress) {
+                            stepCircle.setAttribute('class', 'stepCircle unlocked');
+                            /**
+                             * NB: For the images to render in Safari, they
+                             * need to be declared with `xlink:href` rather
+                             * than the `href` that Chrome and recent Firefox
+                             * are happy with. So we need to use
+                             * `setAttributeNS` with the `xlink` namespace
+                             * definition above.
+                             */
+                            stepCircle.setAttributeNS(XLINK, 'href', this._completeIconUrl);
+                            Polymer.dom(element).appendChild(stepCircle);
+                        } else if (i === this.progress) {
+                            stepCircle.setAttributeNS(XLINK, 'href', this._currentIconUrl);
+                            stepCircle.setAttribute('class', 'stepCircle unlocked');
+                            let avatar = document.createElementNS(XMLNS, 'image');
+                            avatar.setAttribute('class', 'stepCircle unlocked');
+                            avatar.setAttributeNS(null, 'height', '25');
+                            avatar.setAttributeNS(null, 'width', '25');
+                            avatar.setAttributeNS(XLINK, 'href', this._avatarUrl);
+                            avatar.setAttribute('cursor', 'pointer');
+                            avatar.setAttribute('x', (nodes[i].x - 12));
+                            avatar.setAttribute('y', (nodes[i].y - 12));
+                            avatar.setAttribute('index', i);
+                            avatar.onclick = this._onChallengeClick.bind(this);
+                            Polymer.dom(element).appendChild(stepCircle);
+                            Polymer.dom(element).appendChild(avatar);
+                        } else {
+                            stepCircle.setAttributeNS(XLINK, 'href', this._lockedIconUrl);
+                            Polymer.dom(element).appendChild(stepCircle);
+                        }
+                    }
+                },
+                _describeArc (x, y, radius, startAngle, endAngle) {
+                    endAngle = endAngle || 360;
+                    let start = this._polarToCartesian(x, y, radius, endAngle),
+                        end = this._polarToCartesian(x, y, radius, startAngle),
+                        largeArcFlag = endAngle - startAngle <= 180 ? '0' : '1',
+                        d = [
+                            'M', start.x, start.y,
+                            'A', radius, radius, 0, largeArcFlag, 0, end.x, end.y
+                        ].join(' ');
+                    return d;
+                },
+                _polarToCartesian (centerX, centerY, radius, angleInDegrees) {
+                    let angleInRadians = (angleInDegrees - 90) * Math.PI / 180.0;
+                    return {
+                            x: centerX + (radius * Math.cos(angleInRadians)),
+                            y: centerY + (radius * Math.sin(angleInRadians))
+                        };
+                },
+                _drawChallengeProgress () {
+                    let nodes = this._createNodes(this._numNodes, this.radius);
+                    if (!nodes.length){ return; }
+                    this._createChallengeSvg(this.radius,  svg => {
+                        let polyline = document.createElementNS(XMLNS, 'polyline');
+                        polyline.style.strokeDasharray = 4.5;
 
-                    this._drawStepCircles(svg, nodes, 20);
-                });
-            },
-            _onProgressChanged (progress) {
-                let index = progress || 0;
-                if (!this.challengeSet || !this.challengeSet.challenges) {
-                    return;
-                }
-                if (index < this.challengeSet.challenges.length) {
-                    index = progress;
-                } else {
-                    index = this.challengeSet.challenges.length - 1;
-                }
-                let nextChallenge = this.challengeSet.challenges[index];
-                if (nextChallenge) {
-                    this.set('_nextChallenge.title', nextChallenge.title);
-                    this.set('_nextChallenge.slug', nextChallenge.slug);
-                }
-                this._drawChallengeProgress();
-            },
-            _onChallengeClick (e) {
-                if (this.disabled) {
-                    return;
-                }
-                let index = e.target.getAttribute('index');
-                if (index <= this.progress) {
-                    let selectedChallenge = this.challengeSet.challenges[index];
+                        polyline.setAttribute('points',
+                            nodes[this._numNodes - 1].x + ',' + nodes[this._numNodes - 1].y +
+                            ' ' + nodes[this._numNodes - 1].x + ',' +
+                            (nodes[this._numNodes - 1].y + this.radius / 2) + ' '
+                        );
+                        polyline.setAttribute('stroke', '#e0e1e3');
+                        polyline.setAttribute('stroke-width', 7);
+                        if (this._completed) {
+                            polyline.setAttribute('stroke', '#ffb300');
+                            polyline.style.strokeDasharray = 'none';
+                        }
+                        element = svg;
+                        Polymer.dom(element).appendChild(polyline);
+                        let arc = document.createElementNS(XMLNS, 'path');
+                        arc.setAttribute('d', this._describeArc(
+                            this.radius + 25,
+                            this.radius + 25,
+                            this.radius,
+                            360 / this._numNodes,
+                            360));
+                        arc.setAttribute('stroke', '#e0e1e3');
+                        arc.setAttribute('stroke-width', 7);
+                        arc.style.strokeDasharray = 4.5;
+                        arc.setAttribute('fill', 'none');
+                        if (this._completed) {
+                            arc.setAttribute('stroke', '#ffb300');
+                            arc.style.strokeDasharray = 'none';
+                        }
+                        Polymer.dom(element).appendChild(arc);
+
+                        let progressArc = document.createElementNS(XMLNS, 'path');
+                        progressArc.setAttribute('d', this._describeArc(
+                            this.radius + 25,
+                            this.radius + 25,
+                            this.radius,
+                            360 / this._numNodes,
+                            (360 / this._numNodes) * (this.progress + 1)));
+                        progressArc.setAttribute('stroke', '#ffb300');
+                        progressArc.setAttribute('stroke-width', 7);
+                        progressArc.setAttribute('fill', 'none');
+                        Polymer.dom(element).appendChild(progressArc);
+
+                        this._drawStepCircles(svg, nodes, 20);
+                    });
+                },
+                _onProgressChanged (progress) {
+                    let index = progress || 0;
+                    if (!this.challengeSet || !this.challengeSet.challenges) {
+                        return;
+                    }
+                    if (index < this.challengeSet.challenges.length) {
+                        index = progress;
+                    } else {
+                        index = this.challengeSet.challenges.length - 1;
+                    }
+                    let nextChallenge = this.challengeSet.challenges[index];
+                    if (nextChallenge) {
+                        this.set('_nextChallenge.title', nextChallenge.title);
+                        this.set('_nextChallenge.slug', nextChallenge.slug);
+                    }
+                    this._drawChallengeProgress();
+                },
+                _onChallengeClick (e) {
+                    if (this.disabled) {
+                        return;
+                    }
+                    let index = e.target.getAttribute('index');
+                    if (index <= this.progress) {
+                        let selectedChallenge = this.challengeSet.challenges[index];
+                        this.fire('open-kano-code', {
+                            type: 'challenge',
+                            slug: selectedChallenge.slug
+                        });
+                    }
+                },
+                _openNextChallenge (e) {
+                    if (this.disabled) {
+                        return;
+                    }
                     this.fire('open-kano-code', {
                         type: 'challenge',
-                        slug: selectedChallenge.slug
+                        slug: this._nextChallenge.slug
+                    });
+                },
+                _openFirstChallenge () {
+                    if (
+                        !this.challengeSet
+                        || !this.challengeSet.challenges
+                        || !this.challengeSet.challenges.length
+                        || this.disabled
+                    ) {
+                        return;
+                    }
+                    let challengeSlug = this.challengeSet.challenges[0].slug;
+                    this.fire('open-kano-code', {
+                        type: 'challenge',
+                        slug: challengeSlug
+                    });
+                },
+                _computeButtonLabel (completed, progress) {
+                    if (completed) {
+                        return 'Redo';
+                    } else if (progress === 0) {
+                        return 'Start';
+                    } else {
+                        return 'Continue';
+                    }
+                },
+                _challengeFriend () {
+                    this.fire('challenge-friend', {
+                        setTitle: this.challengeSet.title
                     });
                 }
-            },
-            _openNextChallenge (e) {
-                if (this.disabled) {
-                    return;
-                }
-                this.fire('open-kano-code', {
-                    type: 'challenge',
-                    slug: this._nextChallenge.slug
-                });
-            },
-            _openFirstChallenge () {
-                if (
-                    !this.challengeSet
-                    || !this.challengeSet.challenges
-                    || !this.challengeSet.challenges.length
-                    || this.disabled
-                ) {
-                    return;
-                }
-                let challengeSlug = this.challengeSet.challenges[0].slug;
-                this.fire('open-kano-code', {
-                    type: 'challenge',
-                    slug: challengeSlug
-                });
-            },
-            _computeButtonLabel (completed, progress) {
-                if (completed) {
-                    return 'Redo';
-                } else if (progress === 0) {
-                    return 'Start';
-                } else {
-                    return 'Continue';
-                }
-            },
-            _challengeFriend () {
-                this.fire('challenge-friend', {
-                    setTitle: this.challengeSet.title
-                });
-            }
-        });
+            });
+        })();
     </script>
 </dom-module>


### PR DESCRIPTION
Safari won't show `<image>` elements in an SVG with the `href` attribute. This needs to be `xlink:href`, so this commit adds the `xlink` namepsace when adding the image attributes, so that these embedded images are rendered properly. It also tidies up a bit, making `XMLNS` and `XLINK` constants, so that they can be re-used throughout the component.

Fixes the issues outlined in this Trello card: https://trello.com/c/H63CKopL
